### PR TITLE
feat: 指定の場所のMMAPを読み込んで、Unityの座標系に合わせるgetPositionの作成

### DIFF
--- a/Assets/Resources/Material.meta
+++ b/Assets/Resources/Material.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b8ccdef34629d34e8927f3e2f2f62a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Material/Red.mat
+++ b/Assets/Resources/Material/Red.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Red
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 1
+    - _GlossyReflections: 1
+    - _Metallic: 1
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Resources/Material/Red.mat.meta
+++ b/Assets/Resources/Material/Red.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: efba39fb5245bc349810267253a14bbf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/WholeDesign.unity
+++ b/Assets/Scenes/WholeDesign.unity
@@ -994,6 +994,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   spellEffectManager: {fileID: 1358512954}
   isDebug: 0
+  positionMmapPath: /tmp/pos_mmap.txt
 --- !u!4 &972746921
 Transform:
   m_ObjectHideFlags: 0
@@ -1191,7 +1192,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c4dc693060436941a9d8f134dcf9179, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mmapPath: C:/Users/inher/color.txt
+  mmapPath: /tmp/color_mmap.txt
 --- !u!4 &1174947676
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/WholeDesign.unity
+++ b/Assets/Scenes/WholeDesign.unity
@@ -993,6 +993,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spellEffectManager: {fileID: 1358512954}
+  isDebug: 0
 --- !u!4 &972746921
 Transform:
   m_ObjectHideFlags: 0
@@ -1161,6 +1162,51 @@ MonoBehaviour:
   m_BeforeTransparentBundles: []
   m_BeforeStackBundles: []
   m_AfterStackBundles: []
+--- !u!1 &1174947674
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1174947676}
+  - component: {fileID: 1174947675}
+  m_Layer: 0
+  m_Name: UpdateColorHandler
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1174947675
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1174947674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c4dc693060436941a9d8f134dcf9179, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mmapPath: C:/Users/inher/color.txt
+--- !u!4 &1174947676
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1174947674}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -20.206593, y: 18.956434, z: 79.535645}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1358512953
 GameObject:
   m_ObjectHideFlags: 0
@@ -1420,6 +1466,111 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1433305946}
   m_CullTransparentMesh: 1
+--- !u!1 &1468500323
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1468500327}
+  - component: {fileID: 1468500326}
+  - component: {fileID: 1468500325}
+  - component: {fileID: 1468500324}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1468500324
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468500323}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1468500325
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468500323}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: efba39fb5245bc349810267253a14bbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1468500326
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468500323}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1468500327
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468500323}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.6, y: 1.3, z: 63}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1878881005
 GameObject:
   m_ObjectHideFlags: 0
@@ -1748,3 +1899,5 @@ SceneRoots:
   - {fileID: 1378812838}
   - {fileID: 972746921}
   - {fileID: 1358512955}
+  - {fileID: 1468500327}
+  - {fileID: 1174947676}

--- a/Assets/Scripts/Utils/MemoryMapFileManager.cs
+++ b/Assets/Scripts/Utils/MemoryMapFileManager.cs
@@ -27,7 +27,7 @@ public class MemoryMapFileManager : MonoBehaviour
     private float imageWidth = 1920f;
     private float imageHeight = 1080f;
     private float pixelToUnit = 0.01f;
-    private string positionMmapPath = "C:/Users/{ユーザー名}/mmap.txt"; // パスは適宜変更する。
+    public string positionMmapPath = "C:/Users/{ユーザー名}/mmap.txt"; // パスは適宜変更する。
     private MemoryMappedFile positionMmf;
     private MemoryMappedViewAccessor positionAccessor;
     private Vector3 currentPosition = Vector3.zero;

--- a/Assets/Scripts/Utils/UpdateBallColor.cs
+++ b/Assets/Scripts/Utils/UpdateBallColor.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using UnityEngine;
+
+
+/*
+*	杖の先端の色を取得し、指定のmmapに書き込むための関数
+*/
+public class UpdateBallColor : MonoBehaviour
+{
+	public string mmapPath = "C:/Users/{ユーザー名}/color.txt"; // パスは適宜変更する。
+
+	// mmap に書き込むバッファサイズ（3つの double = 24 バイト）
+	private const long MmapSize = sizeof(double) * 3;
+
+	void Update()
+	{
+		if (Input.GetMouseButtonDown(0))
+		{
+			StartCoroutine(CaptureColorAndWrite());
+		}
+	}
+
+	private System.Collections.IEnumerator CaptureColorAndWrite()
+	{
+		yield return new WaitForEndOfFrame();
+
+		Vector2 mousePos = Input.mousePosition;
+		int x = Mathf.FloorToInt(mousePos.x);
+		int y = Mathf.FloorToInt(mousePos.y);
+
+		Texture2D tex = new Texture2D(1, 1, TextureFormat.RGB24, false);
+		tex.ReadPixels(new Rect(x, y, 1, 1), 0, 0);
+		tex.Apply();
+		Color pixelColor = tex.GetPixel(0, 0);
+		Destroy(tex);
+
+		double r = Math.Round(pixelColor.r * 255.0);
+		double g = Math.Round(pixelColor.g * 255.0);
+		double b = Math.Round(pixelColor.b * 255.0);
+
+		// B, G, R の順番で書き込む（OpenCV 等と同じ BGR 系に合わせる想定）
+		WriteColorToMmap(b, g, r);
+
+		Debug.Log($"クリック色 (Unity Color) = R:{pixelColor.r:F3}, G:{pixelColor.g:F3}, B:{pixelColor.b:F3}");
+		Debug.Log($"mmap に書き込んだ色 (0-255) = B:{b}, G:{g}, R:{r}");
+	}
+
+	private void WriteColorToMmap(double b, double g, double r)
+	{
+		try
+		{
+			using (var mmf = MemoryMappedFile.CreateFromFile(mmapPath, FileMode.Open, null, MmapSize))
+			{
+				using (var accessor = mmf.CreateViewAccessor(0, MmapSize, MemoryMappedFileAccess.Write))
+				{
+					// 先頭から 3 つの double を順に書き込む
+					accessor.Write(0 * sizeof(double), b);
+					accessor.Write(1 * sizeof(double), g);
+					accessor.Write(2 * sizeof(double), r);
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			Debug.LogError($"mmap への書き込みに失敗: {ex.Message}");
+		}
+	}
+}

--- a/Assets/Scripts/Utils/UpdateBallColor.cs.meta
+++ b/Assets/Scripts/Utils/UpdateBallColor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c4dc693060436941a9d8f134dcf9179
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 作成したもの
- pythonで指定の場所に作成したmmapを読み込んで、そのデータをunity上に反映させるコードの作成。
　- 現在位置からの最短位置を計算する処理はUnity上で実装しました
　- mmapには、中心座標の候補地がリスト形式で渡されています。
- クリックした際にその場所を中心として、色をpythonに共有するmmapに保存する処理を記述しました。
- クリックの処理を行うempty objectをScene上に追加しました、

# 引継ぎ事項
特になし