### PR TITLE
エフェクトの位置補正をかけやすく

### DIFF
--- a/Assets/Resources/Prefabs/Spells/Catastlavia.prefab
+++ b/Assets/Resources/Prefabs/Spells/Catastlavia.prefab
@@ -1,5 +1,40 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &177084946148355254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 239553076028630353}
+  m_Layer: 0
+  m_Name: Catastlvia_InterParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &239553076028630353
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 177084946148355254}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2733233036730090792}
+  - {fileID: 3732212260411929239}
+  - {fileID: 4660371318918458472}
+  - {fileID: 1681353063123958450}
+  m_Father: {fileID: 245481498054968365}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &2097106237193123054
 GameObject:
   m_ObjectHideFlags: 0
@@ -26,12 +61,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2097106237193123054}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 16, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 245481498054968365}
+  m_Father: {fileID: 239553076028630353}
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!198 &1637578401026662236
 ParticleSystem:
@@ -4860,7 +4895,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 245481498054968365}
+  m_Father: {fileID: 239553076028630353}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7210648229995087721
 MonoBehaviour:
@@ -4909,10 +4944,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2733233036730090792}
-  - {fileID: 3732212260411929239}
-  - {fileID: 4660371318918458472}
-  - {fileID: 1681353063123958450}
+  - {fileID: 239553076028630353}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5511220407257351318
@@ -4932,6 +4964,7 @@ MonoBehaviour:
   particle1: {fileID: 9178305250896481813}
   particle2: {fileID: 2097106237193123054}
   particle3: {fileID: 7098459052300568789}
+  effectParent: {fileID: 239553076028630353}
   postProcessVolume: {fileID: 7210648229995087721}
   defaultIntensity: 10
   middleIntensity: 12
@@ -4967,12 +5000,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7098459052300568789}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 100, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 245481498054968365}
+  m_Father: {fileID: 239553076028630353}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!198 &3255144056899724181
 ParticleSystem:
@@ -9797,12 +9830,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9178305250896481813}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: -0, y: -0.7071068, z: -0, w: 0.7071068}
   m_LocalPosition: {x: -1.5, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 245481498054968365}
+  m_Father: {fileID: 239553076028630353}
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!198 &3668349680618177015
 ParticleSystem:

--- a/Assets/Resources/Prefabs/Spells/Judolazirum.prefab
+++ b/Assets/Resources/Prefabs/Spells/Judolazirum.prefab
@@ -30,7 +30,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7724493659975627593}
+  - {fileID: 6000408508278224725}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: -45, z: 0}
 --- !u!114 &3269978274657789814
@@ -45,6 +45,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d12ccf2cc1058854a8bccae92b79e440, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  effectParent: {fileID: 6000408508278224725}
   postProcessVolume: {fileID: 1095924031294565197}
   smallThunderPrefab: {fileID: 7681576079778179664, guid: 7518d1266da7cb940897def01d75d2b2, type: 3}
   sphereThunderPrefab: {fileID: 6293374856722897421, guid: e472ee9626dca6b4b9854a5da3bfee5a, type: 3}
@@ -59,6 +60,38 @@ MonoBehaviour:
   middleThreshold: 0.7
   minThreshold: 0.3
   finishThreshold: 0.2
+--- !u!1 &6209125868904912936
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6000408508278224725}
+  m_Layer: 0
+  m_Name: Judolazirum_InterParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6000408508278224725
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6209125868904912936}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7724493659975627593}
+  m_Father: {fileID: 7096082802586226110}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &6647230237873264234
 GameObject:
   m_ObjectHideFlags: 0
@@ -85,12 +118,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6647230237873264234}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7096082802586226110}
+  m_Father: {fileID: 6000408508278224725}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &6999144884358313976
 BoxCollider:

--- a/Assets/Resources/Prefabs/Spells/Volzanbel.prefab
+++ b/Assets/Resources/Prefabs/Spells/Volzanbel.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 713608383795165285}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -32,7 +32,7 @@ Transform:
   - {fileID: 531480215074013091}
   - {fileID: 5488882056027695439}
   - {fileID: 3862229768560540394}
-  m_Father: {fileID: 4921532892379101683}
+  m_Father: {fileID: 2036392267434668937}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1188713460086230128
 GameObject:
@@ -64,9 +64,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8559405215362592951}
-  - {fileID: 1854619209397190844}
-  - {fileID: 3256252622885152081}
+  - {fileID: 2036392267434668937}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8213133701654602261
@@ -81,6 +79,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 42de21d1c262bff4dbfd8d18fea0a9ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  effectParent: {fileID: 2036392267434668937}
   postProcessVolume: {fileID: 1763323042304854300}
   beam: {fileID: 713608383795165285}
   globalParticle: {fileID: 4134562627501095395}
@@ -4933,6 +4932,40 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
+--- !u!1 &3843107482811940754
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2036392267434668937}
+  m_Layer: 0
+  m_Name: Volzanbel_InterParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2036392267434668937
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3843107482811940754}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8559405215362592951}
+  - {fileID: 1854619209397190844}
+  - {fileID: 3256252622885152081}
+  m_Father: {fileID: 4921532892379101683}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &3877247660591000170
 GameObject:
   m_ObjectHideFlags: 0
@@ -9796,14 +9829,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4134562627501095395}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4592523073128883596}
   - {fileID: 6120308066718918986}
-  m_Father: {fileID: 4921532892379101683}
+  m_Father: {fileID: 2036392267434668937}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4781017280602861876
 GameObject:
@@ -9835,7 +9868,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4921532892379101683}
+  m_Father: {fileID: 2036392267434668937}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1763323042304854300
 MonoBehaviour:

--- a/Assets/Resources/Prefabs/Spells/Zoltraak.prefab
+++ b/Assets/Resources/Prefabs/Spells/Zoltraak.prefab
@@ -1,5 +1,87 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1130552200239931083
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2905802335359740793}
+  - component: {fileID: 4200703773344748644}
+  - component: {fileID: 2084984398701090626}
+  m_Layer: 0
+  m_Name: Zoltraak_InterParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2905802335359740793
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1130552200239931083}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7854599287654690404}
+  - {fileID: 5537006735754962059}
+  - {fileID: 8658647844041052817}
+  - {fileID: 6535337675392642693}
+  - {fileID: 6072321209997741690}
+  - {fileID: 6087839398699595806}
+  - {fileID: 7305095390087230826}
+  m_Father: {fileID: 1725194174078678742}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!95 &4200703773344748644
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1130552200239931083}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: ce6df29ed4de5c1448b8b9ec1a230301, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &2084984398701090626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1130552200239931083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5d222d5e8421b7439aeefe7b100137d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  postProcessVolume: {fileID: 7958338398043176395}
+  defaultIntensity: 10
+  circleIntensity: 30
+  beamIntensity: 15
+  finishIntensity: 25
+  defaultThreshold: 0.9
+  circleThreshold: 0.2
+  beamThreshold: 0.7
+  finishThreshold: 0.3
 --- !u!1 &1313973250635264489
 GameObject:
   m_ObjectHideFlags: 0
@@ -26,12 +108,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1313973250635264489}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1725194174078678742}
+  m_Father: {fileID: 2905802335359740793}
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!198 &6489422131164436506
 ParticleSystem:
@@ -4839,8 +4921,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1725194174078678742}
-  - component: {fileID: 3569114305004767384}
-  - component: {fileID: 8577850726452908856}
   - component: {fileID: 8122728286557630373}
   m_Layer: 0
   m_Name: Zoltraak
@@ -4862,57 +4942,9 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7854599287654690404}
-  - {fileID: 5537006735754962059}
-  - {fileID: 8658647844041052817}
-  - {fileID: 6535337675392642693}
-  - {fileID: 6072321209997741690}
-  - {fileID: 6087839398699595806}
-  - {fileID: 7305095390087230826}
+  - {fileID: 2905802335359740793}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!95 &3569114305004767384
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1930408320774033011}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: ce6df29ed4de5c1448b8b9ec1a230301, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!114 &8577850726452908856
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1930408320774033011}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f5d222d5e8421b7439aeefe7b100137d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  postProcessVolume: {fileID: 7958338398043176395}
-  defaultIntensity: 10
-  circleIntensity: 30
-  beamIntensity: 15
-  finishIntensity: 25
-  defaultThreshold: 0.9
-  circleThreshold: 0.2
-  beamThreshold: 0.7
-  finishThreshold: 0.3
 --- !u!114 &8122728286557630373
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4955,7 +4987,7 @@ Transform:
   m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1725194174078678742}
+  m_Father: {fileID: 2905802335359740793}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!212 &1814377094515167499
 SpriteRenderer:
@@ -5035,12 +5067,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2515723085352286791}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1725194174078678742}
+  m_Father: {fileID: 2905802335359740793}
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!198 &1882931086376955097
 ParticleSystem:
@@ -9870,7 +9902,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1725194174078678742}
+  m_Father: {fileID: 2905802335359740793}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!198 &8199211974624277495
 ParticleSystem:
@@ -14694,12 +14726,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5205129357273602786}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0.2, y: 0, z: 0}
   m_LocalScale: {x: 0.6, y: 0.6, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1725194174078678742}
+  m_Father: {fileID: 2905802335359740793}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!212 &1837065877064191849
 SpriteRenderer:
@@ -14779,12 +14811,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8009008701179031779}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1725194174078678742}
+  m_Father: {fileID: 2905802335359740793}
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!198 &661083123559240887
 ParticleSystem:
@@ -19613,7 +19645,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1725194174078678742}
+  m_Father: {fileID: 2905802335359740793}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7958338398043176395
 MonoBehaviour:

--- a/Assets/Scenes/WholeDesign.unity
+++ b/Assets/Scenes/WholeDesign.unity
@@ -1111,7 +1111,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 38dfe462fb88a1c4099eead06398066f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  visualizePos: {fileID: 0}
   spellEffectManager: {fileID: 1358512954}
   isDebug: 0
   positionMmapPath: /tmp/pos_mmap.txt
@@ -1219,7 +1218,7 @@ Transform:
   m_GameObject: {fileID: 1014683411}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/Spells/Catastlavia.cs
+++ b/Assets/Scripts/Spells/Catastlavia.cs
@@ -12,6 +12,7 @@ public class Catastlavia : SpellEffectBase
     [SerializeField] private GameObject particle2;
     [SerializeField] private GameObject particle3;
     private Transform effectTransform;
+    [SerializeField] private Transform effectParent;
     private const int x = -1;
     private const float minY = -1;
     private const float maxY = 2;
@@ -49,7 +50,7 @@ public class Catastlavia : SpellEffectBase
         for (int i = 0; i < posNumber; i++)
         {
             float angleX = Mathf.Atan2(pos[i].y, -pos[i].z);
-            GameObject arrow = Instantiate(laviaPrefab, effectTransform);
+            GameObject arrow = Instantiate(laviaPrefab, effectParent);
             arrow.transform.localPosition = pos[i];
             arrow.transform.localRotation = Quaternion.Euler(new(angleX * Mathf.Rad2Deg, 0, 0));
             StartCoroutine(ArrowManage(arrow, 2.99f));
@@ -67,7 +68,7 @@ public class Catastlavia : SpellEffectBase
             float y = UnityEngine.Random.Range(minY, maxY);
             float z = UnityEngine.Random.Range(minZ, maxZ);
             float angleX = Mathf.Atan2(y, -z);
-            GameObject arrow = Instantiate(laviaPrefab2, effectTransform);
+            GameObject arrow = Instantiate(laviaPrefab2, effectParent);
             arrow.transform.localPosition = new(x, y, z);
             arrow.transform.localRotation = Quaternion.Euler(new(angleX * Mathf.Rad2Deg, 0, 0));
             StartCoroutine(ArrowManage(arrow, 0.49f));
@@ -76,7 +77,7 @@ public class Catastlavia : SpellEffectBase
                 float y2 = UnityEngine.Random.Range(minY, maxY);
                 float z2 = UnityEngine.Random.Range(minZ, maxZ);
                 float angleX2 = Mathf.Atan2(y2, -z2);
-                GameObject arrow2 = Instantiate(laviaPrefab2, effectTransform);
+                GameObject arrow2 = Instantiate(laviaPrefab2, effectParent);
                 arrow2.transform.localPosition = new(x, y2, z2);
                 arrow2.transform.localRotation = Quaternion.Euler(new(angleX2 * Mathf.Rad2Deg, 0, 0));
                 StartCoroutine(ArrowManage(arrow2, 0.49f));

--- a/Assets/Scripts/Spells/Judolazirum.cs
+++ b/Assets/Scripts/Spells/Judolazirum.cs
@@ -7,6 +7,7 @@ using UnityEngine.Rendering.PostProcessing;
 public class Judolazirum : SpellEffectBase
 {
     private Transform myTransform;
+    [SerializeField] private Transform effectParent;
     [SerializeField] private PostProcessVolume postProcessVolume;
     private Bloom bloom;
     [SerializeField] private GameObject smallThunderPrefab;
@@ -184,7 +185,7 @@ public class Judolazirum : SpellEffectBase
     }
     private GameObject GenerateThunder(GameObject prefab, Vector3 pos, Vector3 rot)
     {
-        GameObject thunder = Instantiate(prefab, myTransform);
+        GameObject thunder = Instantiate(prefab, effectParent);
         thunder.transform.localPosition = pos;
         thunder.transform.localRotation = Quaternion.Euler(rot);
         return thunder;

--- a/Assets/Scripts/Spells/Volzanbel.cs
+++ b/Assets/Scripts/Spells/Volzanbel.cs
@@ -7,6 +7,7 @@ using UnityEngine.Rendering.PostProcessing;
 public class Volzanbel : SpellEffectBase
 {
     private Transform myTransform;
+    [SerializeField] private Transform effectParent;
     [SerializeField] private PostProcessVolume postProcessVolume;
     private Bloom bloom;
     [SerializeField] private GameObject beam;
@@ -57,7 +58,7 @@ public class Volzanbel : SpellEffectBase
         yield return new WaitForSeconds(0.75f);
         //直前の発光
         StartCoroutine(Flash2());
-        GameObject flash = Instantiate(flashPrefab, myTransform);
+        GameObject flash = Instantiate(flashPrefab, effectParent);
         flash.transform.position = new(1, -1, 0);
         flash.transform.rotation = Quaternion.identity;
         flash.transform.localScale = new(2, 1, 1);
@@ -145,9 +146,9 @@ public class Volzanbel : SpellEffectBase
             }
         }
         yield return new WaitForSeconds(0.25f);
-        GenerateFireGlobal(new(1, 0, -1));
+        GenerateFireGlobal(new(0, 0, -1));
         yield return new WaitForSeconds(0.75f);
-        GenerateFlashGlobal(new(1, -1.5f, -1));
+        GenerateFlashGlobal(new(0, -1.5f, -1));
     }
     //private IEnumerator RandomFire()
     //{
@@ -168,7 +169,7 @@ public class Volzanbel : SpellEffectBase
     //}
     private void GenerateFire(Vector3 pos)
     {
-        GameObject fire = Instantiate(firePrefab, myTransform);
+        GameObject fire = Instantiate(firePrefab, effectParent);
         fire.transform.localPosition = pos;
         fire.transform.rotation = Quaternion.Euler(-90, 0, 0);
         StartCoroutine(ManagePrefab(fire, 1));

--- a/Assets/Scripts/Utils/MemoryMapFileManager.cs
+++ b/Assets/Scripts/Utils/MemoryMapFileManager.cs
@@ -148,7 +148,7 @@ public class MemoryMapFileManager : MonoBehaviour
         //レイルザイデンデバッグ用
         if (Input.GetKeyDown(KeyCode.Alpha2))
         {
-            StartCoroutine(spellEffectManager.OnSpelled(SPELL.Railzaiden, GetPosition(), GetRotation()));
+            StartCoroutine(spellEffectManager.OnSpelled(SPELL.Railzaiden, new (0, 0, 0), Quaternion.identity));
         }
         //カタストラーヴィアデバッグ用
         if (Input.GetKeyDown(KeyCode.Alpha3))
@@ -305,7 +305,7 @@ public class MemoryMapFileManager : MonoBehaviour
                     StartCoroutine(spellEffectManager.OnSpelled(SPELL.Zoltraak, GetPosition(), GetRotation()));
                     break;
                 case 2:
-                    StartCoroutine(spellEffectManager.OnSpelled(SPELL.Railzaiden, GetPosition(), GetRotation()));
+                    StartCoroutine(spellEffectManager.OnSpelled(SPELL.Railzaiden, new(0, 0, 0), Quaternion.identity));
                     break;
                 case 3:
                     StartCoroutine(spellEffectManager.OnSpelled(SPELL.Catastlavia, GetPosition(), GetRotation()));


### PR DESCRIPTION
・プレハブの構造を変え、180°反転などに対応できるようにした。
・レイルザイデンは位置や角度の影響を受けないようにした